### PR TITLE
removing build directory from gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,3 @@
 *.exe
 *.out
 *.app
-
-build/


### PR DESCRIPTION
It should instead go to banjo/.git/info/exclude
